### PR TITLE
CI/CD add hlint and formatting

### DIFF
--- a/.github/workflows/cavefish-server-fourmolu-ci.yml
+++ b/.github/workflows/cavefish-server-fourmolu-ci.yml
@@ -1,0 +1,30 @@
+name: Check Fourmolu formatting
+
+on:
+  push:
+    branches: [ "master", "release/**" ]
+    paths:
+      - 'cavefish-server/**'
+      - '.github/workflows/cavefish-server-fourmolu-ci.yml'
+
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - 'cavefish-server/**'
+      - '.github/workflows/cavefish-server-fourmolu-ci.yml'
+
+jobs:
+  fourmolu-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./cavefish-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Fourmolu check
+        uses: haskell-actions/run-fourmolu@v9
+        with:
+          version: "latest"
+          pattern: |
+            cavefish-server/cavefish/**/*.hs

--- a/.github/workflows/cavefish-server-hlint-ci.yml
+++ b/.github/workflows/cavefish-server-hlint-ci.yml
@@ -1,0 +1,36 @@
+name: HLint
+
+on:
+  push:
+    branches: [ "master", "release/**" ]
+    paths:
+      - 'cavefish-server/**'
+      - '.github/workflows/cavefish-server-hlint-ci.yml'
+
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - 'cavefish-server/**'
+      - '.github/workflows/cavefish-server-hlint-ci.yml'
+
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./cavefish-server
+    steps:
+      - uses: actions/checkout@v4 # Checkout your repository's code
+
+      - name: 'Set up HLint'
+        uses: haskell-actions/hlint-setup@v2
+        with:
+          version: '3.1.6'
+
+      - name: 'Run HLint'
+        uses: haskell-actions/hlint-run@v2
+        with:
+          path: cavefish-server/cavefish/
+          fail-on: never
+        # This step can fail without stopping the workflow

--- a/.github/workflows/cavefish-server-linux-ci.yml
+++ b/.github/workflows/cavefish-server-linux-ci.yml
@@ -1,4 +1,4 @@
-name: Haskell CI
+name: Haskell build and test
 
 on:
   push:
@@ -60,20 +60,6 @@ jobs:
       uses: input-output-hk/actions/base@latest
       with:
         use-sodium-vrf: false # default is true
-
-    - name: Install fourmolu
-      working-directory: ./cavefish-server
-      run: |
-        FOURMOLU_VERSION="0.17.0.0"
-        BINDIR=$HOME/.local/bin
-        mkdir -p "$BINDIR"
-        curl -sSfL "https://github.com/fourmolu/fourmolu/releases/download/v${FOURMOLU_VERSION}/fourmolu-${FOURMOLU_VERSION}-linux-x86_64" -o "$BINDIR/fourmolu"
-        chmod a+x "$BINDIR/fourmolu"
-        echo "$BINDIR" >> $GITHUB_PATH
-
-    - name: Run fourmolu
-      working-directory: ./cavefish-server
-      run: ./scripts/fourmolize.sh
 
     - name: Install Haskell
       id: install-haskell


### PR DESCRIPTION
### Run CI Actions in parallel
Separate Action jobs for `Lint`, `Fourmolu`, and `build&test`. This will allow for quick feed back on `non-critical` errors.

#### Note
Fourmolu failures will fail the job.
Lint failures/warnings will not fail the job. They are mostly for reviews