### PR TITLE
Ci/cabal fmt

### DIFF
--- a/cavefish-server/cavefish/client-backend/cavefish-client-backend.cabal
+++ b/cavefish-server/cavefish/client-backend/cavefish-client-backend.cabal
@@ -1,10 +1,8 @@
 cabal-version:   3.4
 name:            cavefish-client-backend
 version:         0.1.0.0
-
 license:         MIT
 license-file:    LICENSE
-
 build-type:      Simple
 extra-doc-files: CHANGELOG.md
 
@@ -48,8 +46,7 @@ common project-config
 library
   import:          base, project-config
   hs-source-dirs:  src
-  exposed-modules:
-    ClientBackend.Server
+  exposed-modules: ClientBackend.Server
   other-modules:
     ClientBackend.Api
     ClientBackend.App
@@ -58,8 +55,6 @@ library
     ClientBackend.Types
 
   build-depends:
-    , cavefish-core
-    , cavefish-client
     , aeson
     , bytestring
     , cardano-api
@@ -67,6 +62,8 @@ library
     , cardano-crypto-class
     , cardano-ledger-alonzo
     , cardano-ledger-core
+    , cavefish-client
+    , cavefish-core
     , cborg
     , containers
     , cooked-validators
@@ -94,11 +91,11 @@ executable cavefish-client-backend
   hs-source-dirs: app
   main-is:        Main.hs
   build-depends:
-    , cavefish-client-backend
     , bytestring
+    , cavefish-client-backend
     , cooked-validators
     , crypton
     , stm
-    , warp
     , wai
     , wai-cors
+    , warp

--- a/cavefish-server/cavefish/client/cavefish-client.cabal
+++ b/cavefish-server/cavefish/client/cavefish-client.cabal
@@ -95,7 +95,5 @@ test-suite test
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   hs-source-dirs: test
-  other-modules:
-    Spec
-  build-depends:
-    , hspec
+  other-modules:  Spec
+  build-depends:  hspec

--- a/cavefish-server/cavefish/tests/cavefish-tests.cabal
+++ b/cavefish-server/cavefish/tests/cavefish-tests.cabal
@@ -53,7 +53,7 @@ common project-config
     ViewPatterns
 
   ghc-options:
-    -Wall  -Wcompat -Widentities -Wincomplete-record-updates
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields
     -Wredundant-constraints -Wcompat -Wunused-packages
     -Wmissing-import-lists

--- a/cavefish-server/nix/shell.nix
+++ b/cavefish-server/nix/shell.nix
@@ -1,10 +1,10 @@
-{
-  inputs,
-  pkgs,
-  lib,
-  project,
-  utils,
-  ghc,
+{ inputs
+, pkgs
+, lib
+, project
+, utils
+, ghc
+,
 }:
 
 let
@@ -61,11 +61,11 @@ let
 
     hooks = {
       nixpkgs-fmt = {
-        enable = false;
+        enable = true;
         package = pkgs.nixpkgs-fmt;
       };
       cabal-fmt = {
-        enable = false;
+        enable = true;
         package = tools.cabal-fmt;
       };
       stylish-haskell = {
@@ -77,10 +77,10 @@ let
         ];
       };
       fourmolu = {
-        enable = false;
+        enable = true;
         package = tools.fourmolu;
         args = [
-          "--mode"
+          "-m"
           "inplace"
         ];
       };
@@ -93,7 +93,7 @@ let
         ];
       };
       shellcheck = {
-        enable = false;
+        enable = true;
         package = pkgs.shellcheck;
       };
     };
@@ -127,6 +127,7 @@ let
     pkgs.git-lfs
     pkgs.which
     pkgs.watchexec
+    pkgs.ghciwatch
     pkgs.nix-prefetch-git
 
     # Additions for gen-tags.sh

--- a/cavefish-server/wbps/wbps.cabal
+++ b/cavefish-server/wbps/wbps.cabal
@@ -1,5 +1,5 @@
-cabal-version:      3.4
-name:               wbps
+cabal-version:   3.4
+name:            wbps
 
 -- The package version.
 -- See the Haskell package versioning policy (PVP) for standards
@@ -8,16 +8,15 @@ name:               wbps
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:            0.1.0.0
-homepage:           https://github.com/input-output-hk/innovation-cavefish
-license:            Apache-2.0
-license-file:       LICENSE
-author:             Nicolas Henin
-maintainer:         mr.henin@gmail.com
-category:           Cryptography
-build-type:         Simple
-extra-doc-files:    CHANGELOG.md
-
+version:         0.1.0.0
+homepage:        https://github.com/input-output-hk/innovation-cavefish
+license:         Apache-2.0
+license-file:    LICENSE
+author:          Nicolas Henin
+maintainer:      mr.henin@gmail.com
+category:        Cryptography
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
 
 common base
   build-depends: base >=4.9 && <5
@@ -52,62 +51,60 @@ common project-config
     ViewPatterns
 
 library
-    import: base, project-config
-    hs-source-dirs: lib
-    exposed-modules:  
-        WBPS
-        WBPS.Core
-        WBPS.Core.Primitives.Snarkjs
-        WBPS.Core.Primitives.SnarkjsOverFileScheme
-        WBPS.Core.Primitives.Circom
-        WBPS.Core.FileScheme
-        WBPS.Adapter.CardanoCryptoClass.Crypto
-        WBPS.Adapter.Data  
-    build-depends:
-      ,  bytestring
-      , shh    >= 0.7.0  && < 0.8
-      , path   >= 0.9.0  && < 0.10
-      , path-io>= 1.8.0  && < 1.9
-      , transformers
-      , validation
-      , mtl
-      , cardano-crypto-class
-      , text
-      , hex-text
-      , aeson
+  import:          base, project-config
+  hs-source-dirs:  lib
+  exposed-modules:
+    WBPS
+    WBPS.Adapter.CardanoCryptoClass.Crypto
+    WBPS.Adapter.Data
+    WBPS.Core
+    WBPS.Core.FileScheme
+    WBPS.Core.Primitives.Circom
+    WBPS.Core.Primitives.Snarkjs
+    WBPS.Core.Primitives.SnarkjsOverFileScheme
 
-
+  build-depends:
+    , aeson
+    , bytestring
+    , cardano-crypto-class
+    , hex-text
+    , mtl
+    , path                  >=0.9.0 && <0.10
+    , path-io               >=1.8.0 && <1.9
+    , shh                   >=0.7.0 && <0.8
+    , text
+    , transformers
+    , validation
 
 test-suite wbps-unit-tests
-
-    import: base, project-config
-    type:             exitcode-stdio-1.0
-    hs-source-dirs:   tests/unit
-    main-is:          Main.hs
-    other-modules:  
-    build-depends:
-        , wbps
-        , tasty
-        , tasty-hunit
-        , tasty-quickcheck
+  import:         base, project-config
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: tests/unit
+  main-is:        Main.hs
+  other-modules:
+  build-depends:
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , wbps
 
 test-suite wbps-integration-tests
+  import:         base, project-config
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: tests/integration
+  main-is:        Main.hs
+  other-modules:
+    WBPS.Specs.Adapter.GenCardanoKeys
+    WBPS.Specs.Adapter.Test
+    WBPS.Specs.NominalCase
 
-    import: base, project-config
-    type:             exitcode-stdio-1.0
-    hs-source-dirs:   tests/integration
-    main-is:          Main.hs
-    other-modules:  
-      WBPS.Specs.NominalCase
-      WBPS.Specs.Adapter.GenCardanoKeys
-      WBPS.Specs.Adapter.Test
-    build-depends:
-        , path ^>=0.9.6
-        , path-io ^>=1.8.2
-        , wbps
-        , tasty
-        , tasty-hunit
-        , tasty-quickcheck
-        , bytestring
-        , QuickCheck
-        , cardano-crypto-class
+  build-depends:
+    , bytestring
+    , cardano-crypto-class
+    , path                  ^>=0.9.6
+    , path-io               ^>=1.8.2
+    , QuickCheck
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , wbps


### PR DESCRIPTION
Enable githook formatting rules for for the following file types:
- nix
- cabal
- hs
