### PR TITLE
Implement Tracing

### DIFF
--- a/cavefish-server/cavefish/core/cavefish-core.cabal
+++ b/cavefish-server/cavefish/core/cavefish-core.cabal
@@ -66,8 +66,10 @@ library
     Core.Api.Config
     Core.Api.Messages
     Core.Api.State
+    Core.CavefishLogEvent
     Core.Cbor
     Core.Intent
+    Core.Logging
     Core.Observers.Observer
     Core.PaymentProof
     Core.Pke
@@ -80,7 +82,7 @@ library
 
   build-depends:
     , aeson
-    , Blammo
+    , async
     , bytestring
     , cardano-api
     , cardano-binary
@@ -88,12 +90,16 @@ library
     , cardano-ledger-alonzo
     , cardano-ledger-core
     , cborg
+    , clock
     , containers
+    , contra-tracer
     , cooked-validators
     , crypton
     , data-default
+    , exceptions
     , lens
     , memory
+    , monad-time
     , mtl
     , plutus-core
     , plutus-ledger
@@ -101,6 +107,7 @@ library
     , plutus-script-utils
     , plutus-tx
     , plutus-tx-plugin
+    , say
     , servant-server
     , stm
     , text

--- a/cavefish-server/cavefish/core/src/Core/Api/AppContext.hs
+++ b/cavefish-server/cavefish/core/src/Core/Api/AppContext.hs
@@ -1,14 +1,6 @@
 module Core.Api.AppContext where
 
-import Blammo.Logging.Simple (
-  HasLogger (loggerL),
-  Logger,
-  MonadLogger,
-  MonadLoggerIO,
-  WithLogger (WithLogger),
- )
 import Cardano.Api qualified as Api
-import Control.Lens (lens)
 import Control.Monad.Error.Class (MonadError)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (MonadReader, ReaderT, runReaderT)
@@ -48,11 +40,7 @@ data Env = Env
       Api.Tx Api.ConwayEra ->
       MockChainState ->
       IO (Either Text ())
-  , logger :: Logger
   }
-
-instance HasLogger Env where
-  loggerL = lens logger (\x y -> x {logger = y})
 
 newtype AppM a = AppM {unAppM :: ReaderT Env Handler a}
   deriving newtype
@@ -63,7 +51,6 @@ newtype AppM a = AppM {unAppM :: ReaderT Env Handler a}
     , MonadReader Env
     , MonadError ServerError
     )
-  deriving (MonadLogger, MonadLoggerIO) via (WithLogger Env Handler)
 
 runApp :: Env -> AppM a -> Handler a
 runApp env (AppM m) = runReaderT m env

--- a/cavefish-server/cavefish/core/src/Core/Api/Config.hs
+++ b/cavefish-server/cavefish/core/src/Core/Api/Config.hs
@@ -5,7 +5,7 @@
 module Core.Api.Config where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Aeson (ToJSON)
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Default (Default (def))
 import Data.Text.IO qualified
 import GHC.Generics (Generic)
@@ -31,6 +31,8 @@ data HttpServer = HttpServer
 
 instance ToJSON HttpServer
 
+instance FromJSON HttpServer
+
 instance Default HttpServer where
   def =
     HttpServer
@@ -45,6 +47,8 @@ newtype Wbps = Wbps
   deriving (Show, Generic)
 
 instance ToJSON Wbps
+
+instance FromJSON Wbps
 
 instance FromValue Wbps where
   fromValue = parseTableFromValue (Wbps <$> reqKey "path")
@@ -63,6 +67,8 @@ newtype ServiceProviderFee = ServiceProviderFee
 
 instance ToJSON ServiceProviderFee
 
+instance FromJSON ServiceProviderFee
+
 instance FromValue ServiceProviderFee where
   fromValue = parseTableFromValue (ServiceProviderFee <$> reqKey "amount")
 
@@ -79,6 +85,8 @@ newtype TransactionExpiry = TransactionExpiry
   deriving (Show, Generic)
 
 instance ToJSON TransactionExpiry
+
+instance FromJSON TransactionExpiry
 
 instance FromValue TransactionExpiry where
   fromValue = parseTableFromValue (TransactionExpiry <$> reqKey "seconds")
@@ -100,6 +108,8 @@ data Config = Config
   deriving (FromValue) via GenericTomlTable Config
 
 instance ToJSON Config
+
+instance FromJSON Config
 
 instance Default Config where
   def =

--- a/cavefish-server/cavefish/core/src/Core/CavefishLogEvent.hs
+++ b/cavefish-server/cavefish/core/src/Core/CavefishLogEvent.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | This module defines traceable events for the Cavefish application.
+module Core.CavefishLogEvent (
+  -- * Traceable Events
+  HttpRoundTrip (..),
+  ConfigurationLoaded (..),
+  ErrorOccurred (..),
+  CavefishLogEvent (..),
+  RequestDuration (..),
+  HttpServerError (..),
+) where
+
+import Core.Api.Config (Config)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+newtype RequestDuration = RequestDuration
+  { milliseconds :: Double
+  }
+  deriving (Show, Generic)
+
+instance ToJSON RequestDuration
+
+instance FromJSON RequestDuration
+
+-- | Represents an HTTP round trip event.
+data HttpRoundTrip = HttpRoundTrip
+  { path :: Text
+  , method :: Text
+  , duration :: RequestDuration
+  }
+  deriving (Show, Generic)
+
+instance ToJSON HttpRoundTrip
+
+instance FromJSON HttpRoundTrip
+
+-- | Represents the event of loading the application configuration.
+newtype ConfigurationLoaded = ConfigurationLoaded
+  { config :: Config
+  }
+  deriving (Show, Generic)
+
+instance ToJSON ConfigurationLoaded
+
+instance FromJSON ConfigurationLoaded
+
+-- | Represents an error event in the application.
+newtype ErrorOccurred = ErrorOccurred
+  { errorMessage :: Text
+  }
+  deriving (Show, Generic)
+
+instance ToJSON ErrorOccurred
+
+instance FromJSON ErrorOccurred
+
+data HttpServerError = HttpServerError
+  { path :: Text
+  , method :: Text
+  , status :: Int
+  , errorMessage :: Text
+  , duration :: RequestDuration
+  }
+  deriving (Show, Generic)
+
+instance ToJSON HttpServerError
+
+instance FromJSON HttpServerError
+
+-- | Sum type representing all traceable events in the Cavefish application.
+data CavefishLogEvent
+  = LogHttpRoundTrip HttpRoundTrip
+  | LogConfigurationLoaded ConfigurationLoaded
+  | LogErrorOccurred ErrorOccurred
+  | LogHttpServerError HttpServerError
+  | LogSPConfigLoaded Config
+  deriving (Show, Generic)
+
+instance ToJSON CavefishLogEvent
+
+instance FromJSON CavefishLogEvent

--- a/cavefish-server/cavefish/core/src/Core/Logging.hs
+++ b/cavefish-server/cavefish/core/src/Core/Logging.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | A simple tracer implementation that logs messages as JSON to stdout,
+-- with support for verbosity levels and capturing logs on failure.
+module Core.Logging (
+  -- * Tracer
+  Tracer (..),
+  natTracer,
+  nullTracer,
+  traceWith,
+
+  -- * Using it
+  Verbosity (..),
+  Envelope (..),
+  withTracer,
+  withTracerOutputTo,
+  showLogsOnFailure,
+  traceInTVar,
+  contramap,
+) where
+
+import Control.Concurrent (myThreadId)
+import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.STM.TBQueue (
+  flushTBQueue,
+  newTBQueueIO,
+  readTBQueue,
+  writeTBQueue,
+ )
+import Control.Concurrent.STM.TVar (
+  TVar,
+  modifyTVar,
+  newTVarIO,
+  readTVarIO,
+ )
+import Control.Monad (forM_, forever, (>=>))
+import Control.Monad.Catch (
+  MonadCatch,
+  finally,
+  onException,
+ )
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.Time (MonadTime, currentTime)
+import Control.Tracer (
+  Tracer (Tracer, runTracer),
+  contramap,
+  natTracer,
+  nullTracer,
+  traceWith,
+ )
+import Data.Aeson (FromJSON, ToJSON, pairs, (.=))
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as LBS
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Encoding (decodeUtf8)
+import Data.Time (UTCTime)
+import GHC.Conc (atomically)
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Say (say)
+import System.IO (Handle, hFlush, stdout)
+import Text.Read (readMaybe)
+
+data Verbosity = Quiet | Verbose Text
+  deriving (Eq, Show, Generic)
+
+instance ToJSON Verbosity
+
+instance FromJSON Verbosity
+
+-- | Provides logging metadata for entries.
+data Envelope a = Envelope
+  { timestamp :: UTCTime
+  , threadId :: Int
+  , namespace :: Text
+  , message :: a
+  }
+  deriving (Eq, Show, Generic)
+
+instance FromJSON a => FromJSON (Envelope a)
+
+instance ToJSON a => ToJSON (Envelope a) where
+  toEncoding Envelope {timestamp, threadId, namespace, message} =
+    pairs $
+      mconcat
+        [ "timestamp" .= timestamp
+        , "threadId" .= threadId
+        , "namespace" .= namespace
+        , "message" .= message
+        ]
+
+defaultQueueSize :: Natural
+defaultQueueSize = 500
+
+-- | Start logging thread and acquire a 'Tracer'. This tracer will dump all
+-- messsages on @stdout@, one message per line, formatted as JSON. This tracer
+-- is wrapping 'msg' into an 'Envelope' with metadata.
+withTracer ::
+  forall m msg a.
+  (MonadIO m, MonadTime m, ToJSON msg) =>
+  Verbosity ->
+  (Tracer m msg -> IO a) ->
+  IO a
+withTracer Quiet = ($ nullTracer)
+withTracer (Verbose namespace) = withTracerOutputTo stdout namespace
+
+-- | Start logging thread acquiring a 'Tracer', outputting JSON formatted
+-- messages to some 'Handle'. This tracer is wrapping 'msg' into an 'Envelope'
+-- with metadata.
+withTracerOutputTo ::
+  forall m msg a.
+  (MonadIO m, MonadTime m, ToJSON msg) =>
+  Handle ->
+  Text ->
+  (Tracer m msg -> IO a) ->
+  IO a
+withTracerOutputTo hdl namespace action = do
+  msgQueue <- liftIO (newTBQueueIO @(Envelope msg) defaultQueueSize)
+  withAsync (writeLogs msgQueue) $ \_ ->
+    action (tracer msgQueue) `finally` flushLogs msgQueue
+  where
+    tracer queue =
+      tbqTracer $
+        mkEnvelope namespace >=> liftIO . atomically . writeTBQueue queue
+
+    writeLogs queue =
+      forever $ do
+        atomically (readTBQueue queue) >>= write . Aeson.encode
+        hFlush hdl
+
+    flushLogs queue = liftIO $ do
+      entries <- atomically $ flushTBQueue queue
+      forM_ entries (write . Aeson.encode)
+      hFlush hdl
+
+    write bs = LBS.hPut hdl (bs <> "\n")
+
+tbqTracer :: (msg -> m ()) -> Tracer m msg
+tbqTracer action = Tracer $ \msg -> action msg
+
+-- | Capture logs and output them to stdout when an exception was raised by the
+-- given 'action'. This tracer is wrapping 'msg' into an 'Envelope' with
+-- metadata.
+showLogsOnFailure ::
+  (MonadCatch m, MonadIO m, MonadTime m, ToJSON msg) =>
+  (Tracer m msg -> m a) ->
+  m a
+showLogsOnFailure action = do
+  tvar <- liftIO (newTVarIO [])
+  action (traceInTVar tvar)
+    `onException` ( liftIO (readTVarIO tvar)
+                      >>= mapM_ (say . TL.toStrict . decodeUtf8 . Aeson.encode) . reverse
+                  )
+
+traceInTVar ::
+  (MonadIO m, MonadTime m) =>
+  TVar [Envelope msg] ->
+  Tracer m msg
+traceInTVar tvar = tbqTracer $ \msg -> do
+  envelope <- mkEnvelope "" msg
+  liftIO $ atomically $ modifyTVar tvar (envelope :)
+
+-- * Internal functions
+
+mkEnvelope :: (MonadTime m, MonadIO m) => Text -> msg -> m (Envelope msg)
+mkEnvelope namespace message = do
+  timestamp <- currentTime
+  -- threadId <- mkThreadId <$> (liftIO myThreadId)
+  threadId <- mkThreadId <$> (liftIO myThreadId)
+  pure $ Envelope {namespace, timestamp, threadId, message}
+  where
+    -- NOTE(AB): This is a bit contrived but we want a numeric threadId and we
+    -- get some text which we know the structure of
+    mkThreadId = fromMaybe 0 . readMaybe . Text.unpack . Text.drop 9 . Text.pack . show

--- a/cavefish-server/cavefish/server/cavefish-server.cabal
+++ b/cavefish-server/cavefish/server/cavefish-server.cabal
@@ -63,18 +63,18 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Sp.Emulator
+    Sp.Middleware
     Sp.Server
 
   build-depends:
-    , aeson
-    , Blammo
-    , Blammo-wai
     , bytestring
     , cardano-api
     , cavefish-core
+    , clock
     , cooked-validators
     , crypton
     , data-default
+    , http-types
     , mtl
     , plutus-ledger
     , plutus-script-utils
@@ -96,7 +96,6 @@ executable cavefish-server
   data-file:      config/config.toml
   main-is:        Main.hs
   build-depends:
-    , Blammo
     , bytestring
     , cavefish-core
     , cavefish-server

--- a/cavefish-server/cavefish/server/src/Sp/Emulator.hs
+++ b/cavefish-server/cavefish/server/src/Sp/Emulator.hs
@@ -8,7 +8,6 @@
 --    mock chain state.
 module Sp.Emulator where
 
-import Blammo.Logging.Simple (Logger)
 import Cardano.Api qualified as Api
 import Control.Concurrent.STM (TVar, atomically, readTVarIO, writeTVar)
 import Control.Monad.Identity (runIdentity)
@@ -27,7 +26,6 @@ import Core.Api.AppContext (
     build,
     clientRegistration,
     complete,
-    logger,
     pending,
     pkePublic,
     pkeSecret,
@@ -80,7 +78,6 @@ mkCookedEnv ::
   PkeSecretKey ->
   Wallet ->
   FileScheme ->
-  Logger ->
   Cfg.Config ->
   Env
 mkCookedEnv
@@ -92,7 +89,6 @@ mkCookedEnv
   pkeSk
   spWallet
   wbpsSchemeValue
-  logger
   config =
     env
     where
@@ -112,7 +108,6 @@ mkCookedEnv
           , wbpsScheme = wbpsSchemeValue
           , build = buildWithCooked mockState env
           , submit = submitWithCooked mockState env
-          , logger
           }
 
 -- | Build a transaction using the Cooked mock chain.

--- a/cavefish-server/cavefish/server/src/Sp/Middleware.hs
+++ b/cavefish-server/cavefish/server/src/Sp/Middleware.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Sp.Middleware (
+  cavefishMiddleware,
+) where
+
+import Core.CavefishLogEvent (
+  CavefishLogEvent (LogHttpRoundTrip, LogHttpServerError),
+  HttpRoundTrip (HttpRoundTrip, duration, method, path),
+  HttpServerError (HttpServerError, duration, errorMessage, method, path, status),
+  RequestDuration (RequestDuration),
+ )
+import Core.Logging (Verbosity (Verbose), traceWith, withTracer)
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding.Error (lenientDecode)
+import Network.HTTP.Types.Status (statusCode, statusMessage)
+import Network.Wai (
+  Middleware,
+  Request,
+  Response,
+  rawQueryString,
+  requestMethod,
+  responseStatus,
+ )
+import System.Clock qualified as Clock
+
+timingTraceMiddleware :: Middleware
+timingTraceMiddleware app req respond =
+  (withTracer $ Verbose "SP.Http.Roundtrip") $ \tr -> do
+    begin <- getTime
+    -- Call the next application in the stack
+    app req $ \resp -> do
+      duration <- RequestDuration . toMilliseconds . subtract begin <$> getTime
+      let (path, method) = requestDetails req
+          traceEvent =
+            LogHttpRoundTrip $
+              HttpRoundTrip
+                { path
+                , method
+                , duration
+                }
+      traceWith tr traceEvent
+      respond resp
+
+errStatusTraceMiddleware :: Middleware
+errStatusTraceMiddleware app req respond = do
+  (withTracer $ Verbose "SP.Http.Erro-Status") $ \tr -> do
+    begin <- getTime
+    app req $ \resp -> do
+      duration <- RequestDuration . toMilliseconds . subtract begin <$> getTime
+      if (getStatusCode resp >= 400)
+        then
+          let (method, path) = requestDetails req
+              statusCode :: Int = getStatusCode resp
+              message = decodeUtf8 . statusMessage . responseStatus $ resp
+           in traceWith tr $
+                LogHttpServerError $
+                  HttpServerError
+                    { path
+                    , method
+                    , status = statusCode
+                    , errorMessage = message
+                    , duration
+                    }
+        else pure ()
+      respond resp
+
+getStatusCode :: Response -> Int
+getStatusCode = statusCode . responseStatus
+
+cavefishMiddleware :: Middleware
+cavefishMiddleware = timingTraceMiddleware . errStatusTraceMiddleware
+
+getTime :: IO Clock.TimeSpec
+getTime = Clock.getTime Clock.Monotonic
+
+toMilliseconds :: Clock.TimeSpec -> Double
+toMilliseconds ts = fromIntegral (Clock.toNanoSecs ts) / nsPerMs
+
+nsPerMs :: Double
+nsPerMs = 1000000
+
+requestDetails :: Request -> (Text, Text)
+requestDetails req =
+  ( decodeUtf8 (requestMethod req)
+  , decodeUtf8 (rawQueryString req)
+  )
+
+decodeUtf8 :: ByteString -> Text
+decodeUtf8 = decodeUtf8With lenientDecode

--- a/cavefish-server/cavefish/tests/cavefish-tests.cabal
+++ b/cavefish-server/cavefish/tests/cavefish-tests.cabal
@@ -89,7 +89,6 @@ test-suite test
 
   build-depends:
     , aeson
-    , Blammo
     , bytestring
     , cardano-api
     , cavefish-client

--- a/cavefish-server/cavefish/tests/test/Core/CborSpec.hs
+++ b/cavefish-server/cavefish/tests/test/Core/CborSpec.hs
@@ -2,7 +2,6 @@
 
 module Core.CborSpec (spec) where
 
-import Blammo.Logging.Simple (defaultLogSettings, newLogger)
 import Cardano.Api qualified as Api
 import Client.Mock qualified as Mock
 import Control.Concurrent.STM (newTVarIO)
@@ -34,7 +33,6 @@ spec =
       completeStore <- newTVarIO Map.empty
       clientStore <- newTVarIO Map.empty
       wbpsScheme <- mkFileSchemeFromRoot "../../wbps"
-      logger <- newLogger defaultLogSettings
       let config :: Config = def
 
       let env =
@@ -47,7 +45,6 @@ spec =
               testPkeSecretKey
               testSpWallet
               wbpsScheme
-              logger
               config
 
       prepareReq <-

--- a/cavefish-server/cavefish/tests/test/Spec.hs
+++ b/cavefish-server/cavefish/tests/test/Spec.hs
@@ -9,7 +9,6 @@
 
 module Spec (spec) where
 
-import Blammo.Logging.Simple (Logger, defaultLogSettings, newLogger)
 import Cardano.Api qualified as Api
 import Client.Impl qualified as Client
 import Client.Mock (MockClient (mcRun, mcVerificationContext), mkFinaliseReq)
@@ -121,9 +120,8 @@ mkEnv ::
   CompleteStore ->
   ClientRegistrationStore ->
   TVar MockChainState ->
-  Logger ->
   Env
-mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger =
+mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar =
   let config :: Config = def
    in mkCookedEnv
         mockStateVar
@@ -134,7 +132,6 @@ mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger =
         testPkeSecretKey
         testSpWallet
         wbpsScheme
-        logger
         config
 
 expectedUserPublicKeyHex :: Text
@@ -165,8 +162,7 @@ spec = do
       completeStore <- newTVarIO Map.empty
       clientRegVar <- newTVarIO Map.empty
       mockStateVar <- newTVarIO initialMockState
-      logger <- newLogger defaultLogSettings
-      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger
+      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar
       let mockClient0 = Mock.initMockClient (runApp env) testClientSecretKey
       mockClient <- runHandlerOrFail (Mock.register mockClient0)
       case Mock.mcVerificationContext mockClient of
@@ -279,8 +275,7 @@ spec = do
       completeStore <- newTVarIO Map.empty
       clientRegVar <- newTVarIO Map.empty
       mockStateVar <- newTVarIO initialMockState
-      logger <- newLogger defaultLogSettings
-      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger
+      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar
       let mockClient0 = Mock.initMockClient (runApp env) testClientSecretKey
       mockClient <- runHandlerOrFail (Mock.register mockClient0)
       let registeredClientId = Mock.mcClientId mockClient
@@ -325,8 +320,7 @@ spec = do
       completeStore <- newTVarIO Map.empty
       clientRegVar <- newTVarIO Map.empty
       mockStateVar <- newTVarIO initialMockState
-      logger <- newLogger defaultLogSettings
-      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger
+      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar
           mockClient0 = Mock.initMockClient (runApp env) testClientSecretKey
       mockClient <- runHandlerOrFail (Mock.register mockClient0)
       mcVerificationContext mockClient `shouldBe` expectedValue
@@ -345,8 +339,7 @@ spec = do
         completeStore <- newTVarIO Map.empty
         clientRegVar <- newTVarIO Map.empty
         mockStateVar <- newTVarIO initialMockState
-        logger <- newLogger defaultLogSettings
-        let env = mkEnv wbpsSchemeTmp pendingStore completeStore clientRegVar mockStateVar logger
+        let env = mkEnv wbpsSchemeTmp pendingStore completeStore clientRegVar mockStateVar
             mockClient0 = Mock.initMockClient (runApp env) testClientSecretKey
         result <- runExceptT (runHandler' (Mock.register mockClient0))
         case result of
@@ -363,8 +356,7 @@ spec = do
       completeStore <- newTVarIO Map.empty
       clientRegVar <- newTVarIO Map.empty
       mockStateVar <- newTVarIO initialMockState
-      logger <- newLogger defaultLogSettings
-      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger
+      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar
       let mockClient0 = Mock.initMockClient (runApp env) testClientSecretKey
       mockClient <- runHandlerOrFail (Mock.register mockClient0)
       let ClientId clientUuid = Mock.mcClientId mockClient
@@ -378,8 +370,7 @@ spec = do
       completeStore <- newTVarIO Map.empty
       clientRegVar <- newTVarIO Map.empty
       mockStateVar <- newTVarIO initialMockState
-      logger <- newLogger defaultLogSettings
-      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger
+      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar
       let mockClient0 = Mock.initMockClient (runApp env) testClientSecretKey
       mockClient <- runHandlerOrFail (Mock.register mockClient0)
       let ClientId clientUuid = Mock.mcClientId mockClient
@@ -421,8 +412,7 @@ spec = do
       completeStore <- newTVarIO Map.empty
       clientRegVar <- newTVarIO Map.empty
       mockStateVar <- newTVarIO initialMockState
-      logger <- newLogger defaultLogSettings
-      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger
+      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar
           clientEnv = mkClientEnv env
       AskSubmission.Outputs {result = finalResult} <-
         runHandlerOrFail $
@@ -444,8 +434,7 @@ spec = do
       completeStore <- newTVarIO Map.empty
       clientRegVar <- newTVarIO Map.empty
       mockStateVar <- newTVarIO initialMockState
-      logger <- newLogger defaultLogSettings
-      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar logger
+      let env = mkEnv wbpsScheme pendingStore completeStore clientRegVar mockStateVar
       let application = pure (mkApp env)
       Warp.testWithApplication application $ \port -> do
         manager <- newManager defaultManagerSettings

--- a/cavefish-server/nix/shell.nix
+++ b/cavefish-server/nix/shell.nix
@@ -45,7 +45,7 @@ let
   tools = allTools.${ghc};
 
   hlswrapper = pkgs.writeShellScriptBin "haskell-language-server-wrapper" ''
-    #!/bin/bash
+    #!/usr/bin/env bash
     exec haskell-language-server
   '';
 


### PR DESCRIPTION
### Implement contra-tracer to trace CavefishLoggingEvents
This is continuation of issue #74 
This PR adds additional traces:
- Excpetion
- Roundtrip elapsed time

### To verify
```
cabal test all
``` 
all tests will pass and you should see output similar to:
```
Http server roundtrip
{"timestamp":"2025-12-03T00:14:32.183025413Z","threadId":47,"namespace":"SP.Http.Roundtrip","message":{"contents":{"duration":{"milliseconds":1.597956},"method":"","path":"POST"},"tag":"LogHttpRoundTrip"}}
```

```
cabal run cavefish-server
```
Will produce:

```Using config file: /home/kayvan/dev/workspaces/iohk/wt/innovation/innovation-cavefish/74/logging-tracable-events/cavefish-server/cavefish/server/./config/config.toml
{"timestamp":"2025-12-03T00:11:59.203818144Z","threadId":1,"namespace":"SP.Server","message":{"contents":{"httpServer":{"host":"0.0.0.0","port":8080},"serviceProviderFee":{"amount":200},"transactionExpiry":{"seconds":3000},"wbps":{"path":"wbps"}},"tag":"LogSPConfigLoaded"}}
```

> Note
Subsuquent PRs can change the verbosity of traces by adding parameters to [config.toml
](https://github.com/input-output-hk/innovation-cavefish/blob/master/cavefish-server/cavefish/server/config/config.toml)