### PR TITLE
Fix-CI Use correct revision

### DIFF
--- a/cavefish-server/cabal.project
+++ b/cavefish-server/cabal.project
@@ -25,7 +25,7 @@ with-compiler: ghc-9.6.6
 
 index-state:
   , hackage.haskell.org 2025-06-22T20:18:27Z
-  , cardano-haskell-packages 2025-06-20T09:11:51Z
+  , cardano-haskell-packages 2025-09-15T19:20:34Z
 
 write-ghc-environment-files: never
 
@@ -47,8 +47,8 @@ constraints:
 source-repository-package
     type: git
     location: https://github.com/intersectMBO/cardano-node-emulator
-    tag: a265da66259245cdb96e23959de575400ea99400
-    --sha256: 01146nd9m728i2vhq0dl6hbyk16l9mls9lkq84yj1jal7rddgkdd
+    tag: c6e2071bfe1004de2e2ebb9875b5b3b049405a9c
+    --sha256: 0xqazabvvafbvf9k1b7iqn8vpddksn7pqa0kf6044wmd2232nm0p
     subdir:
       plutus-script-utils
       plutus-ledger
@@ -57,14 +57,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/tweag/cooked-validators
-    tag: e7951e28c9e3658c2a823919a348dc232cba1160
-    --sha256: 1xjln2qgzp1wi4wsig5xb877y17k60j6k71lwj9yvjxkz44z5agi
+    tag: b6ada83b1ac02afd09c1f6838a626f38ed062640
+    --sha256: 1fq0ybhksz7wns5grpkla9cwmkzk39wllkv4wshm8qmnhaxripyf
     subdir:
       .
-
-source-repository-package
-  type: git
-  location: https://github.com/IntersectMBO/cardano-api
-  tag: cardano-api-10.18.0.0
-  subdir: cardano-api
-  --sha256: 1j4znqv2kkp994khmj6j5v1skcp8p4gvrgi68zam78lpbaf7kj6h


### PR DESCRIPTION
This PR fixes the CI failure of PR  #97 
Use correct revision of cardno-node-emulator & cooked validator with respect to cardano-api 10.18.0.0