### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/prototype/nix/outputs.nix
+++ b/prototype/nix/outputs.nix
@@ -43,7 +43,6 @@ let
 
   hydraJobsPerSystem = {
     "x86_64-linux" = defaultHydraJobs;
-    "x86_64-darwin" = defaultHydraJobs;
     "aarch64-linux" = defaultHydraJobs;
     "aarch64-darwin" = defaultHydraJobs;
   };


### PR DESCRIPTION
- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.